### PR TITLE
changed dependency from `node-uuid` to `uuid'

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "bluebird": "^3.4.1",
     "debug": "^2.2.0",
     "moment": "^2.14.1",
-    "node-uuid": "^1.4.7",
-    "rethinkdbdash": "^2.3.20"
+    "rethinkdbdash": "^2.3.20",
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/job.js
+++ b/src/job.js
@@ -1,5 +1,5 @@
 const logger = require('./logger')(module)
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const moment = require('moment')
 const enums = require('./enums')
 const is = require('./is')

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,6 +1,6 @@
 const logger = require('./logger')(module)
 const EventEmitter = require('events').EventEmitter
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const Promise = require('bluebird')
 const is = require('./is')
 const enums = require('./enums')


### PR DESCRIPTION
Hi 
As you can see in https://github.com/broofa/node-uuid/issues/142 `node-uuid` is due to be deprecated in favor of `uuid` https://github.com/defunctzombie/node-uuid 

Also see 
https://github.com/request/request/pull/2182
https://github.com/broofa/node-uuid/issues/116

I'm already using `uuid` in a project that's about to go live and I'm about to use your queue since my needs are very basic and I didn't want to set up rabbitmq or similar
It would be very nice to depend on just one version of (node-)uuid