### PR TITLE
Passing an object to `createLog` adds it to  a `data` key to the log entry

### DIFF
--- a/src/job.js
+++ b/src/job.js
@@ -125,16 +125,24 @@ class Job {
     return jobCopy
   }
 
-  createLog (message, type = enums.log.information, status = this.status) {
-    logger(`createLog [${message}] [${type}] [${status}]`)
-    return {
+  createLog (data, type = enums.log.information, status = this.status) {
+    logger(`createLog [${data}] [${type}] [${status}]`)
+    const newLog ={
       date: new Date(),
       queueId: this.q.id,
       type: type,
       status: status,
       retryCount: this.retryCount,
-      message: message
+      message: null
     }
+    if(is.string(data)){
+      newLog.message = data
+    }
+    if(is.object(data)){
+      newLog.data = data
+      newLog.message = enums.message.seeLogData
+    }
+    return newLog
   }
 
   addLog (log) {

--- a/tests/job.spec.js
+++ b/tests/job.spec.js
@@ -5,13 +5,14 @@ const tError = require('./test-error')
 const enums = require('../src/enums')
 const Job = require('../src/job')
 const tData = require('./test-options').tData
+const lData = require('./test-options').lData
 const Queue = require('../src/queue')
 const tOpts = require('./test-options')
 
 module.exports = function () {
   return new Promise((resolve, reject) => {
     test('job', (t) => {
-      t.plan(94)
+      t.plan(101)
 
       const q = new Queue(tOpts.cxn(), tOpts.default())
 
@@ -203,7 +204,7 @@ module.exports = function () {
         t.equal(jobsFromDb[0].progress, 50, 'Job progress valid')
 
         // ---------- Update Job ----------
-        t.comment('job: Update Job')
+        t.comment('job: Update Job with string message')
         savedJob.newData = tData
         savedJob.timeout = newTimeout
         return savedJob.update(tData)
@@ -214,6 +215,22 @@ module.exports = function () {
         t.equal(jobsFromDb[0].id, savedJob.id, 'Job retrieved successfully')
         t.equal(jobsFromDb[0].newData, tData, 'Job new data valid')
         t.equal(jobsFromDb[0].timeout, newTimeout, 'Job new timeout valid')
+
+        // ---------- Update Job Passing `data` object ----------
+        t.comment('job: Update Job with Object message')
+        savedJob.newData = tData
+        savedJob.timeout = newTimeout
+        return savedJob.update(lData)
+      }).then((updateResult) => {
+        t.ok(updateResult, 'Job update returned true')
+        return q.getJob(savedJob.id)
+      }).then((jobsFromDb) => {
+        const lastLogData = jobsFromDb[0].log[jobsFromDb[0].log.length - 1];
+        t.equal(jobsFromDb[0].id, savedJob.id, 'Job retrieved successfully')
+        t.equal(jobsFromDb[0].timeout, newTimeout, 'Job new timeout valid')
+        t.equal(lastLogData.message, enums.message.seeLogData, 'Job log message property valid')
+        t.equal(lastLogData.data.one_key, lData.one_key, 'Job log message property valid')
+        t.equal(lastLogData.data.some_other_key, lData.some_other_key, 'Job log data property valid')
 
         removeEventHandlers()
         return q.reset()

--- a/tests/test-options.js
+++ b/tests/test-options.js
@@ -4,6 +4,7 @@ const dbName = module.exports.dbName = 'rjqJobQueueTests'
 const queueName = module.exports.queueName = 'rjqJobQueueTestJobs'
 
 module.exports.tData = 'The quick brown fox jumped over the lazy dog'
+module.exports.lData = { one_key: 'The quick brown fox jumped over the lazy dog', some_other_key: 0.2 }
 
 module.exports.cxn = function () {
   return {


### PR DESCRIPTION
This is a proposed solution for #17 

I'm _really_ new to using tape so I might have overlloked something. If that is the case let me know

Tests are green apart from one that fails this way on master:
```
    ✖ test exited without ending
    -----------------------------
      operator: fail




  Failed Tests: There was 1 failure

    queue-change: Event Summary

      ✖ test exited without ending```